### PR TITLE
Convert to ubyte after resizing

### DIFF
--- a/src/unraphael/dash/widgets.py
+++ b/src/unraphael/dash/widgets.py
@@ -10,6 +10,7 @@ from config import (
 )
 from scipy.cluster.hierarchy import linkage
 from seaborn import clustermap
+from skimage import img_as_ubyte
 
 from unraphael.feature import (
     heatmap_to_condensed_distance_matrix,
@@ -87,7 +88,7 @@ def load_config_widget():
     )
 
 
-def load_images_widget(**loader_kwargs):
+def load_images_widget(as_ubyte: bool = False, **loader_kwargs):
     """Widget to load images."""
 
     load_example = st.sidebar.checkbox('Load example', value=False, key='load_example')
@@ -106,6 +107,9 @@ def load_images_widget(**loader_kwargs):
         raise ValueError('No images were loaded')
 
     images = equalize_width_widget(images)
+
+    if as_ubyte:
+        images = {name: img_as_ubyte(image) for name, image in images.items()}
 
     return images
 

--- a/src/unraphael/io.py
+++ b/src/unraphael/io.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import imageio.v3 as imageio
-from skimage import img_as_ubyte
 from skimage.color import gray2rgb, rgb2gray
 from skimage.transform import resize
 
@@ -34,7 +33,6 @@ def load_images(
     *,
     width: None | int = None,
     as_gray: bool = True,
-    as_ubyte: bool = False,
 ) -> dict[str, np.ndarray]:
     """Load images through `imageio.imread` and do some preprocessing."""
     images = {}
@@ -51,10 +49,7 @@ def load_images(
                 im = gray2rgb(im)
 
         if width:
-            resize_to_width(im, width=width)
-
-        if as_ubyte:
-            im = img_as_ubyte(im)
+            im = resize_to_width(im, width=width)
 
         images[name] = im
 


### PR DESCRIPTION
This PR fixes a bug introduced in #66 that resizes after converting to ubyte. This PR swaps the order of operations.