### PR TITLE
Use `ImageType` in all pages

### DIFF
--- a/src/unraphael/feature.py
+++ b/src/unraphael/feature.py
@@ -9,6 +9,8 @@ from skimage.feature import ORB, SIFT, match_descriptors
 from skimage.measure import ransac
 from skimage.transform import FundamentalMatrixTransform
 
+from .types import ImageType
+
 
 @dataclass
 class FeatureContainer:
@@ -34,7 +36,7 @@ class FeatureContainer:
 
 
 def detect_and_extract(
-    images: dict[str, np.ndarray], *, method: str, **kwargs
+    images: list[ImageType], *, method: str, **kwargs
 ) -> dict[str, FeatureContainer]:
     """`extractor` must have `detect_and_extract` method."""
     features = {}
@@ -46,12 +48,12 @@ def detect_and_extract(
     else:
         raise ValueError(method)
 
-    for i, (name, im) in enumerate(images.items()):
-        extractor.detect_and_extract(im)
+    for i, image in enumerate(images):
+        extractor.detect_and_extract(image.data)
 
-        features[name] = FeatureContainer(
-            name=name,
-            image=im,
+        features[image.name] = FeatureContainer(
+            name=image.name,
+            image=image.data,
             keypoints=extractor.keypoints,
             descriptors=extractor.descriptors,
             scales=extractor.scales,

--- a/src/unraphael/types.py
+++ b/src/unraphael/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
-from typing import Any
+from typing import Any, Callable
 
 import numpy as np
 
@@ -14,3 +14,6 @@ class ImageType:
 
     def replace(self, **changes):
         return replace(self, **changes)
+
+    def apply(self, func: Callable, **kwargs):
+        return self.replace(data=func(self.data, **kwargs))


### PR DESCRIPTION
This PR updates the pages to use the `ImageType` in all pages. This makes the code a bit more easy to work with, because we don't have to deal with dicts anymore to pass data around. And the name of the data can now be retrieved as an attribute from the data class.

Follows up on #68 