### PR TITLE
Fixed cw_ssim error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,4 @@ target/
 
 # Mypy cache
 .mypy_cache/
+.qodo

--- a/src/unraphael/dash/pages/5_cluster.py
+++ b/src/unraphael/dash/pages/5_cluster.py
@@ -475,7 +475,7 @@ def select_similarity_measure() -> str:
     """Select the similarity measure for clustering complete figures."""
     return st.selectbox(
         'Select similarity measure:',
-        ['SIFT', 'SSIM', 'CW-SSIM', 'IW-SSIM', 'FSIM', 'MSE', 'Brushstrokes'],
+        ['SIFT', 'SSIM', 'IW-SSIM', 'FSIM', 'MSE', 'Brushstrokes'],
         help='Basis for clustering images.',
         key='similarity_measure',
     )


### PR DESCRIPTION
This pull request includes changes to the `image_clustering.py` file, primarily focused on enhancing the CW-SSIM calculation and adding new imports. Additionally, there is a minor update in the `5_cluster.py` file to adjust the similarity measure options.

Enhancements to CW-SSIM calculation:

* [`src/unraphael/dash/image_clustering.py`](diffhunk://#diff-710f2847bc038ff1a169d5faf8e661d01fe9e90e870b447bed32f62079541a09R549-R604): Implemented the original CW-SSIM algorithm from Wang and Simoncelli, including grayscale conversion, wavelet transform, and detailed computation of the CW-SSIM index. This replaces the previous use of `pyssim.SSIM`.

Imports and dependencies:

* [`src/unraphael/dash/image_clustering.py`](diffhunk://#diff-710f2847bc038ff1a169d5faf8e661d01fe9e90e870b447bed32f62079541a09R30): Added `scipy.signal` import to support the wavelet transform in the CW-SSIM calculation.
* [`src/unraphael/dash/image_clustering.py`](diffhunk://#diff-710f2847bc038ff1a169d5faf8e661d01fe9e90e870b447bed32f62079541a09R54-R57): Introduced a fix for `torch.classes.__path__` to avoid potential issues with the `torch` library path.

Updates to similarity measure options:

* [`src/unraphael/dash/pages/5_cluster.py`](diffhunk://#diff-2750a7bc19be755cb5259aa7d39571b418ea7eddad99bb827147bdf884946ccfL478-R478): Removed 'CW-SSIM' from the list of similarity measures available for clustering images, likely due to the changes in its implementation.